### PR TITLE
GitHub ActionsでLintチェックを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
 
   lint-backend:
     name: Backend Lint (Rust)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -45,11 +45,6 @@ jobs:
             src-tauri/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Check formatting
         working-directory: src-tauri


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフロー(`lint.yml`)を追加
- PRとmainへのpush時に自動でlintチェックを実行
- **フロントエンド**: Biome によるTypeScript/Reactコードのチェック
- **バックエンド**: `cargo fmt --check` と `cargo clippy -D warnings` によるRustコードのチェック

## Test plan
- [x] PRを作成してActionsが自動で起動されることを確認
- [x] フロントエンドのBiome checkが正常に完了することを確認
- [x] バックエンドのrustfmt + clippyが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)