### PR TITLE
タスクリストのチェックボックス位置ずれを修正

### DIFF
--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -63,8 +63,19 @@
   gap: 8px;
 }
 
+.editor-wrapper .tiptap ul[data-type="taskList"] li > div {
+  flex: 1;
+  min-height: 1.7em;
+}
+
+.editor-wrapper .tiptap ul[data-type="taskList"] li > div > p {
+  margin: 0;
+}
+
 .editor-wrapper .tiptap ul[data-type="taskList"] li label {
-  margin-top: 3px;
+  display: flex;
+  align-items: center;
+  height: 1.7em;
 }
 
 .editor-wrapper


### PR DESCRIPTION
## Summary
- チェックボックスがテキストと垂直方向にずれていた問題を修正
- labelをflexboxで中央揃えし、コンテンツ領域の高さと余白を調整

## Test plan
- [x] タスクリスト作成時にチェックボックスがテキストと同じ行に揃って表示される
- [x] 複数行のタスクアイテムでもレイアウトが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)