### PR TITLE
サイドバーのメモ一覧を更新日の降順でソート

### DIFF
--- a/src/hooks/useMemos.ts
+++ b/src/hooks/useMemos.ts
@@ -59,11 +59,17 @@ export function useMemos() {
       setCurrentMemo((prev) => (prev ? { ...prev, body } : null));
       const title = extractTitle(body);
       setMemos((prev) =>
-        prev.map((m) =>
-          m.id === currentMemo.meta.id
-            ? { ...m, title, updated_at: new Date().toISOString() }
-            : m,
-        ),
+        prev
+          .map((m) =>
+            m.id === currentMemo.meta.id
+              ? { ...m, title, updated_at: new Date().toISOString() }
+              : m,
+          )
+          .sort(
+            (a, b) =>
+              new Date(b.updated_at).getTime() -
+              new Date(a.updated_at).getTime(),
+          ),
       );
     },
     [currentMemo],


### PR DESCRIPTION
## Summary
- メモ編集時にサイドバーのリストが `updated_at` の降順で再ソートされるように修正
- 編集したメモが即座にサイドバーの先頭に移動するようになる

## 変更内容
`useMemos.ts` の `updateCurrentBody` で `updated_at` を更新した後、`.sort()` を追加してリストを再ソート。

バックエンド (`commands.rs`) では既に `updated_at` 降順でソートしていたが、フロントエンドの `setMemos` 内の `map()` は元の順番を維持するだけだったため、編集中にリアルタイムで順番が変わらなかった。

## Test plan
- [x] メモを編集して、サイドバーで編集したメモが先頭に移動することを確認
- [x] 複数メモを切り替えて編集し、都度正しく並び替えされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)