### PR TITLE
ci: Homebrew配布の自動化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build-and-release:
     name: Build and Release
     runs-on: macos-latest
+    environment: main
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- mainへのpush時にTauriアプリをビルドしGitHub Releaseを自動作成
- リリース後、`ryunosuke121/homebrew-tap`のCask formulaを自動更新
- バージョンが既にリリース済みの場合はスキップ

## セットアップ手順
1. GitHub Personal Access Token (classic)を作成（`repo`スコープ付き）
2. hyutリポジトリのSettings → Secrets → Actionsに`HOMEBREW_TAP_TOKEN`として登録
3. `tauri.conf.json`のversionを更新してmainにpushすると自動リリース

## インストール方法（ユーザー向け）
```bash
brew tap ryunosuke121/tap
brew install --cask hyut
```

## Test plan
- [x] `HOMEBREW_TAP_TOKEN`シークレットを設定
- [ ] mainにマージ後、GitHub Releaseが作成されることを確認
- [ ] homebrew-tapのCask formulaが更新されることを確認
- [ ] `brew tap ryunosuke121/tap && brew install --cask hyut`でインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)