### PR TITLE
docs: READMEにライセンスセクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ brew install --cask ryunosuke121/tap/hyut
 ## 開発
 
 開発に参加する場合は [DEVELOPMENT.md](DEVELOPMENT.md) を参照してください。
+
+## ライセンス
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- READMEの末尾にライセンスセクションを追加し、LICENSEファイルへのリンクを記載

## Test plan
- [x] `make lint` が通ること
- [x] README末尾にライセンスセクションが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)