### PR TITLE
fix: 空行から始まるメモのタイトルがおかしくなる問題を修正

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -48,7 +48,7 @@ pub fn list_memos() -> Result<Vec<MemoSummary>, String> {
         }
     }
 
-    summaries.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    summaries.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
     Ok(summaries)
 }
 
@@ -64,7 +64,7 @@ pub fn save_memo(id: String, body: String) -> Result<Memo, String> {
     let dir = memo_dir();
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
 
-    let path = dir.join(format!("{}.md", &id));
+    let path = dir.join(format!("{}.md", id));
     let now = Utc::now();
 
     let memo = if path.exists() {
@@ -115,7 +115,7 @@ pub fn create_memo() -> Result<Memo, String> {
         body: String::new(),
     };
 
-    let path = dir.join(format!("{}.md", &id));
+    let path = dir.join(format!("{}.md", id));
     let serialized = memo::serialize_memo(&memo);
     fs::write(&path, serialized).map_err(|e| e.to_string())?;
     Ok(memo)

--- a/src-tauri/src/memo.rs
+++ b/src-tauri/src/memo.rs
@@ -49,13 +49,23 @@ pub fn serialize_memo(memo: &Memo) -> String {
     format!("---\n{}---\n{}", yaml, memo.body)
 }
 
+// Tiptap's markdown serializer renders an empty paragraph as a literal
+// "&nbsp;" (or a raw NBSP char) to preserve blank lines, so a blank
+// first line isn't actually an empty string here.
+fn is_blank_line(line: &str) -> bool {
+    line.replace("&nbsp;", "")
+        .replace('\u{00A0}', "")
+        .trim()
+        .is_empty()
+}
+
 pub fn extract_title(body: &str) -> String {
     for line in body.lines() {
         let trimmed = line.trim();
         if let Some(stripped) = trimmed.strip_prefix("# ") {
             return stripped.trim().to_string();
         }
-        if !trimmed.is_empty() {
+        if !is_blank_line(trimmed) {
             return trimmed.chars().take(50).collect();
         }
     }

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,10 +1,17 @@
+// Tiptap's markdown serializer renders an empty paragraph as a literal
+// "&nbsp;" (or a raw NBSP char) to preserve blank lines, so a blank
+// first line isn't actually an empty string here.
+function isBlankLine(line: string): boolean {
+  return line.replace(/&nbsp;| /gi, "").trim().length === 0;
+}
+
 export function extractTitle(markdown: string): string {
   for (const line of markdown.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.startsWith("# ")) {
       return trimmed.slice(2).trim();
     }
-    if (trimmed.length > 0) {
+    if (!isBlankLine(trimmed)) {
       return trimmed.slice(0, 50);
     }
   }


### PR DESCRIPTION
TiptapのMarkdownシリアライザは空段落を "&nbsp;" として出力するため、
最初の行が空だとタイトル抽出時にその "&nbsp;" 自体がタイトルとして
扱われていた。フロント(frontmatter.ts)とバックエンド(memo.rs)の
タイトル抽出ロジックの両方で、&nbsp;/NBSPのみの行を空行として
スキップするよう修正。

Fixes #10

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018SCyfVMqhXgqe6NmaJzTZR