### PR TITLE
test: フロントエンドの公開メソッドにユニットテストを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-frontend:
+    name: Frontend Test (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hyut",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
@@ -33,6 +34,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.4",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -46,6 +49,13 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -339,6 +349,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1850,6 +1870,85 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.0.tgz",
@@ -2436,6 +2535,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2709,11 +2816,46 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2840,6 +2982,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
@@ -2932,6 +3081,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3145,6 +3302,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -3266,6 +3433,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3317,6 +3495,16 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3448,6 +3636,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/prosemirror-changeset": {
@@ -3685,6 +3889,14 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3693,6 +3905,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-from-string": {
@@ -3815,6 +4041,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.4",
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/src/hooks/__tests__/useAppState.test.ts
+++ b/src/hooks/__tests__/useAppState.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppState } from "../useAppState";
+
+describe("useAppState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults lastMemoId to null when nothing is persisted", () => {
+    const { result } = renderHook(() => useAppState());
+    expect(result.current.lastMemoId).toBeNull();
+  });
+
+  it("restores lastMemoId from localStorage on mount", () => {
+    localStorage.setItem(
+      "hyut-app-state",
+      JSON.stringify({ lastMemoId: "existing-id" }),
+    );
+    const { result } = renderHook(() => useAppState());
+    expect(result.current.lastMemoId).toBe("existing-id");
+  });
+
+  it("falls back to null when localStorage contains invalid JSON", () => {
+    localStorage.setItem("hyut-app-state", "not valid json");
+    const { result } = renderHook(() => useAppState());
+    expect(result.current.lastMemoId).toBeNull();
+  });
+
+  it("setLastMemoId updates state and persists it to localStorage", () => {
+    const { result } = renderHook(() => useAppState());
+
+    act(() => {
+      result.current.setLastMemoId("memo-1");
+    });
+
+    expect(result.current.lastMemoId).toBe("memo-1");
+    expect(JSON.parse(localStorage.getItem("hyut-app-state") ?? "{}")).toEqual({
+      lastMemoId: "memo-1",
+    });
+  });
+
+  it("setLastMemoId can clear the stored id back to null", () => {
+    const { result } = renderHook(() => useAppState());
+
+    act(() => {
+      result.current.setLastMemoId("memo-1");
+    });
+    act(() => {
+      result.current.setLastMemoId(null);
+    });
+
+    expect(result.current.lastMemoId).toBeNull();
+    expect(JSON.parse(localStorage.getItem("hyut-app-state") ?? "{}")).toEqual({
+      lastMemoId: null,
+    });
+  });
+});

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const saveMemoMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/commands", () => ({
+  saveMemo: saveMemoMock,
+}));
+
+import { useAutoSave } from "../useAutoSave";
+
+describe("useAutoSave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    saveMemoMock.mockReset();
+    saveMemoMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not save immediately when save() is called", () => {
+    const { result } = renderHook(() => useAutoSave(1000));
+
+    act(() => {
+      result.current.save("memo-1", "hello");
+    });
+
+    expect(saveMemoMock).not.toHaveBeenCalled();
+  });
+
+  it("saves after the debounce delay elapses", async () => {
+    const { result } = renderHook(() => useAutoSave(1000));
+
+    act(() => {
+      result.current.save("memo-1", "hello");
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(saveMemoMock).toHaveBeenCalledWith("memo-1", "hello");
+    expect(saveMemoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the debounce timer on repeated calls, saving only the latest body", async () => {
+    const { result } = renderHook(() => useAutoSave(1000));
+
+    act(() => {
+      result.current.save("memo-1", "first");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    act(() => {
+      result.current.save("memo-1", "second");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(saveMemoMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(saveMemoMock).toHaveBeenCalledTimes(1);
+    expect(saveMemoMock).toHaveBeenCalledWith("memo-1", "second");
+  });
+
+  it("flush() saves immediately and cancels the pending timer", async () => {
+    const { result } = renderHook(() => useAutoSave(1000));
+
+    act(() => {
+      result.current.save("memo-1", "hello");
+    });
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(saveMemoMock).toHaveBeenCalledWith("memo-1", "hello");
+    expect(saveMemoMock).toHaveBeenCalledTimes(1);
+
+    // Advancing time afterward should not trigger a second save.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(saveMemoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush() is a no-op when there is nothing pending", async () => {
+    const { result } = renderHook(() => useAutoSave(1000));
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(saveMemoMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useMemos.test.ts
+++ b/src/hooks/__tests__/useMemos.test.ts
@@ -1,0 +1,177 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Memo } from "../../types/memo";
+
+const ensureMemoDirMock = vi.hoisted(() => vi.fn());
+const listMemosMock = vi.hoisted(() => vi.fn());
+const loadMemoMock = vi.hoisted(() => vi.fn());
+const createMemoMock = vi.hoisted(() => vi.fn());
+const deleteMemoMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/commands", () => ({
+  ensureMemoDir: ensureMemoDirMock,
+  listMemos: listMemosMock,
+  loadMemo: loadMemoMock,
+  createMemo: createMemoMock,
+  deleteMemo: deleteMemoMock,
+}));
+
+import { useMemos } from "../useMemos";
+
+const summary1 = {
+  id: "1",
+  title: "First",
+  created_at: "2024-01-01T00:00:00.000Z",
+  updated_at: "2024-01-01T00:00:00.000Z",
+};
+const summary2 = {
+  id: "2",
+  title: "Second",
+  created_at: "2024-01-02T00:00:00.000Z",
+  updated_at: "2024-01-02T00:00:00.000Z",
+};
+
+describe("useMemos", () => {
+  beforeEach(() => {
+    ensureMemoDirMock.mockReset().mockResolvedValue("/home/user/hyut");
+    listMemosMock.mockReset().mockResolvedValue([summary1, summary2]);
+    loadMemoMock.mockReset();
+    createMemoMock.mockReset();
+    deleteMemoMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("initializes by ensuring the memo dir and loading the list", async () => {
+    const { result } = renderHook(() => useMemos());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(ensureMemoDirMock).toHaveBeenCalledTimes(1);
+    expect(result.current.memos).toEqual([summary1, summary2]);
+  });
+
+  it("selectMemo loads a memo and sets it as current", async () => {
+    const memo = {
+      meta: { id: "1", created_at: "t", updated_at: "t" },
+      body: "content",
+    };
+    loadMemoMock.mockResolvedValue(memo);
+
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectMemo("1");
+    });
+
+    expect(loadMemoMock).toHaveBeenCalledWith("1");
+    expect(result.current.currentMemo).toEqual(memo);
+  });
+
+  it("createNew creates a memo, sets it current, and refreshes the list", async () => {
+    const newMemo = {
+      meta: { id: "3", created_at: "t", updated_at: "t" },
+      body: "",
+    };
+    createMemoMock.mockResolvedValue(newMemo);
+
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    listMemosMock.mockResolvedValue([summary1, summary2, newMemo]);
+
+    let created: Memo | undefined;
+    await act(async () => {
+      created = await result.current.createNew();
+    });
+
+    expect(created).toEqual(newMemo);
+    expect(result.current.currentMemo).toEqual(newMemo);
+    expect(listMemosMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("remove deletes the memo, clears currentMemo if it was selected, and refreshes", async () => {
+    const memo = {
+      meta: { id: "1", created_at: "t", updated_at: "t" },
+      body: "content",
+    };
+    loadMemoMock.mockResolvedValue(memo);
+
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectMemo("1");
+    });
+    expect(result.current.currentMemo).toEqual(memo);
+
+    listMemosMock.mockResolvedValue([summary2]);
+
+    await act(async () => {
+      await result.current.remove("1");
+    });
+
+    expect(deleteMemoMock).toHaveBeenCalledWith("1");
+    expect(result.current.currentMemo).toBeNull();
+    expect(result.current.memos).toEqual([summary2]);
+  });
+
+  it("remove does not clear currentMemo when a different memo is deleted", async () => {
+    const memo = {
+      meta: { id: "1", created_at: "t", updated_at: "t" },
+      body: "content",
+    };
+    loadMemoMock.mockResolvedValue(memo);
+
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectMemo("1");
+    });
+
+    await act(async () => {
+      await result.current.remove("2");
+    });
+
+    expect(deleteMemoMock).toHaveBeenCalledWith("2");
+    expect(result.current.currentMemo).toEqual(memo);
+  });
+
+  it("updateCurrentBody updates the body, title, and re-sorts the memo list", async () => {
+    const memo = {
+      meta: { id: "1", created_at: "t", updated_at: "t" },
+      body: "old body",
+    };
+    loadMemoMock.mockResolvedValue(memo);
+
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectMemo("1");
+    });
+
+    act(() => {
+      result.current.updateCurrentBody("# New Title\nsome text");
+    });
+
+    expect(result.current.currentMemo?.body).toBe("# New Title\nsome text");
+    const updated = result.current.memos.find((m) => m.id === "1");
+    expect(updated?.title).toBe("New Title");
+    // Updated memo should now be sorted first (most recently updated).
+    expect(result.current.memos[0].id).toBe("1");
+  });
+
+  it("updateCurrentBody is a no-op when there is no current memo", async () => {
+    const { result } = renderHook(() => useMemos());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.updateCurrentBody("some text");
+    });
+
+    expect(result.current.currentMemo).toBeNull();
+  });
+});

--- a/src/lib/__tests__/commands.test.ts
+++ b/src/lib/__tests__/commands.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+import {
+  createMemo,
+  deleteMemo,
+  ensureMemoDir,
+  listMemos,
+  loadMemo,
+  saveMemo,
+} from "../commands";
+
+describe("commands", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("ensureMemoDir invokes ensure_memo_dir and returns the result", async () => {
+    invokeMock.mockResolvedValue("/home/user/hyut");
+    const result = await ensureMemoDir();
+    expect(invokeMock).toHaveBeenCalledWith("ensure_memo_dir");
+    expect(result).toBe("/home/user/hyut");
+  });
+
+  it("listMemos invokes list_memos and returns the result", async () => {
+    const summaries = [
+      { id: "1", title: "a", created_at: "t", updated_at: "t" },
+    ];
+    invokeMock.mockResolvedValue(summaries);
+    const result = await listMemos();
+    expect(invokeMock).toHaveBeenCalledWith("list_memos");
+    expect(result).toBe(summaries);
+  });
+
+  it("loadMemo invokes load_memo with the given id", async () => {
+    const memo = {
+      meta: { id: "abc", created_at: "t", updated_at: "t" },
+      body: "b",
+    };
+    invokeMock.mockResolvedValue(memo);
+    const result = await loadMemo("abc");
+    expect(invokeMock).toHaveBeenCalledWith("load_memo", { id: "abc" });
+    expect(result).toBe(memo);
+  });
+
+  it("saveMemo invokes save_memo with id and body", async () => {
+    const memo = {
+      meta: { id: "abc", created_at: "t", updated_at: "t" },
+      body: "new body",
+    };
+    invokeMock.mockResolvedValue(memo);
+    const result = await saveMemo("abc", "new body");
+    expect(invokeMock).toHaveBeenCalledWith("save_memo", {
+      id: "abc",
+      body: "new body",
+    });
+    expect(result).toBe(memo);
+  });
+
+  it("createMemo invokes create_memo and returns the result", async () => {
+    const memo = {
+      meta: { id: "new", created_at: "t", updated_at: "t" },
+      body: "",
+    };
+    invokeMock.mockResolvedValue(memo);
+    const result = await createMemo();
+    expect(invokeMock).toHaveBeenCalledWith("create_memo");
+    expect(result).toBe(memo);
+  });
+
+  it("deleteMemo invokes delete_memo with the given id", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    await deleteMemo("abc");
+    expect(invokeMock).toHaveBeenCalledWith("delete_memo", { id: "abc" });
+  });
+});

--- a/src/lib/__tests__/frontmatter.test.ts
+++ b/src/lib/__tests__/frontmatter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { extractTitle } from "../frontmatter";
+
+describe("extractTitle", () => {
+  it("uses the H1 heading as the title", () => {
+    expect(extractTitle("# Hello World\nsome body text")).toBe("Hello World");
+  });
+
+  it("trims whitespace around the H1 heading", () => {
+    expect(extractTitle("#   Padded Title   \nbody")).toBe("Padded Title");
+  });
+
+  it("falls back to the first non-blank line when there is no H1", () => {
+    expect(extractTitle("just a plain line\nsecond line")).toBe(
+      "just a plain line",
+    );
+  });
+
+  it("skips leading blank lines before picking a title", () => {
+    expect(extractTitle("\n\n  \nActual content here")).toBe(
+      "Actual content here",
+    );
+  });
+
+  it("skips lines that are only &nbsp; placeholders", () => {
+    expect(extractTitle("&nbsp;\n&nbsp;\nReal title")).toBe("Real title");
+  });
+
+  it("truncates a long first line to 50 characters", () => {
+    const long = "a".repeat(80);
+    const result = extractTitle(long);
+    expect(result).toBe("a".repeat(50));
+    expect(result.length).toBe(50);
+  });
+
+  it("returns Untitled for an empty string", () => {
+    expect(extractTitle("")).toBe("Untitled");
+  });
+
+  it("returns Untitled when the markdown is entirely blank lines", () => {
+    expect(extractTitle("\n \n&nbsp;\n")).toBe("Untitled");
+  });
+
+  it("does not treat a heading level other than H1 as a title", () => {
+    expect(extractTitle("## Not an H1\nfallback text")).toBe("## Not an H1");
+  });
+});


### PR DESCRIPTION
## Summary
- `src/lib/frontmatter.ts` の `extractTitle` に対するユニットテストを追加(H1抽出、フォールバック、`&nbsp;`処理、50文字切り詰めなど)
- `src/lib/commands.ts` の Tauri IPC ラッパー6関数(`ensureMemoDir`, `listMemos`, `loadMemo`, `saveMemo`, `createMemo`, `deleteMemo`)に対して `invoke` をモックしたテストを追加
- `src/hooks/useAppState.ts`, `useAutoSave.ts`, `useMemos.ts` の公開フックに対するテストを追加(localStorage永続化、デバウンス保存、メモ一覧のCRUDとソート挙動など)
- フックのテストに `@testing-library/react` を新規devDependencyとして追加

Rustバックエンド(`commands.rs`, `memo.rs`)の公開関数は本セッションのLinux環境ではTauri/webkit2gtk依存のコンパイルができず動作確認ができないため、今回のスコープからは対象外としました。必要であればmacOS環境での追加対応を検討ください。

## Test plan
- [x] `npx vitest run` — 全6テストファイル・38テスト成功
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npx @biomejs/biome check src/` — lintエラーなし
- [x] `npm run build` — プロダクションビルド成功


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaCeaurRC3GAf4efV59fsW)_