### PR TITLE
fix: tiptap 3.29.2 の型変更に追従し、CIでtsc型チェックを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run TypeScript type check
+        run: npx tsc --noEmit
+
       - name: Run Vitest
         run: npm run test

--- a/src/extensions/__tests__/inlineCode.test.ts
+++ b/src/extensions/__tests__/inlineCode.test.ts
@@ -20,7 +20,7 @@ function typeText(editor: Editor, text: string) {
   for (const char of text) {
     const { from, to } = editor.state.selection;
     const handled = editor.view.someProp("handleTextInput", (f) =>
-      f(editor.view, from, to, char),
+      f(editor.view, from, to, char, () => editor.state.tr),
     );
     if (!handled) {
       editor.commands.insertContent(char);
@@ -45,11 +45,14 @@ describe("inline code input rule", () => {
     const doc = editor.getJSON();
     const paragraph = doc.content?.[0];
     const textNodes = paragraph?.content ?? [];
-    const codeNode = textNodes.find((node) =>
-      node.marks?.some((mark) => mark.type === "code"),
+    const codeNode = textNodes.find(
+      (node) =>
+        "text" in node && node.marks?.some((mark) => mark.type === "code"),
     );
 
     expect(editor.getText()).toBe("hello world");
-    expect(codeNode?.text).toBe("world");
+    expect(codeNode && "text" in codeNode ? codeNode.text : undefined).toBe(
+      "world",
+    );
   });
 });


### PR DESCRIPTION
@tiptap/* を 3.29.2 に上げた際、handleTextInput の引数数と
getJSON() の戻り値型が変わり inlineCode.test.ts が型エラーになっていた。
CI(vitest)・Lint(Biome)は型チェックを行わないため main マージ後も
気づかれず、release.yml の npm run build (tsc && vite build) でのみ
発覚していた。CIワークフローに tsc --noEmit を追加し、以後は
PR/main push 時点で型エラーを検出できるようにする。