### PR TITLE
起動直後にウィンドウを表示するよう修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,8 @@ pub fn run() {
                             macos::show_window(ns_window);
                         }
                     })?;
+
+                macos::show_window(ns_window);
             }
 
             #[cfg(not(target_os = "macos"))]
@@ -106,9 +108,7 @@ pub fn run() {
                             }
                         }
                     })?;
-            }
 
-            if cfg!(debug_assertions) {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();


### PR DESCRIPTION
## Summary

- リリースビルド（`npm run tauri build`）では `debug_assertions` が false になるため、起動時にウィンドウを表示する経路が存在せず、`Cmd+Shift+M` を押すまでウィンドウが一切表示されなかった
- `src-tauri/src/lib.rs` の `setup()` から `if cfg!(debug_assertions) { ... }` の条件分岐を撤去し、ビルド種別に関わらず起動直後に必ずウィンドウを表示するように変更
- macOS分岐では既に取得済みの `ns_window` を使って `macos::show_window(ns_window)` を呼び出し、非macOS分岐では既存の `app.get_webview_window("main")` から `show()` / `set_focus()` を呼ぶ形に統一
- グローバルショートカットによるトグル表示/非表示のロジックは変更なし

Fixes #29

## Test plan

- [x] `cargo fmt --check src-tauri/src/lib.rs` を実行しフォーマット崩れがないことを確認
- [ ] `npm run tauri build` でリリースビルドを作成し、Finderから `hyut.app` を起動してショートカットを押さずにウィンドウが表示されることを確認（このサンドボックス環境はLinuxかつGTK系依存ライブラリのインストールがネットワーク制限で失敗するため、macOS実機での確認が必要）
- [ ] `Cmd+Shift+M` によるトグル表示/非表示が引き続き正常に動作することを確認
- [ ] `npm run tauri dev` でも起動直後の表示にリグレッションがないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnQBDukfZyqbUMNFJWAz5P)_