### PR TITLE
fix: IME変換候補パネルがウィンドウに隠れる問題を修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ mod macos {
             NSWindowCollectionBehavior::CanJoinAllSpaces
                 | NSWindowCollectionBehavior::FullScreenAuxiliary,
         );
-        ns_window.setLevel(101); // NSPopUpMenuWindowLevel
+        ns_window.setLevel(3); // NSFloatingWindowLevel
 
         // Liquid Glass: transparent window background
         let clear = NSColor::clearColor();


### PR DESCRIPTION
ウィンドウレベルを NSPopUpMenuWindowLevel(101) から NSFloatingWindowLevel(3)
に変更。IME候補パネルも同程度のレベルで描画されるため、同レベルだと
アプリウィンドウが前面に来て候補を隠してしまっていた。

Fixes #24