### PR TITLE
release: mainへのpushトリガーからworkflow_dispatchへ変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "リリースするバージョン番号（例: 1.1.0）"
+        required: true
+        type: string
 
 concurrency:
   group: release
@@ -37,15 +41,50 @@ jobs:
           key: ${{ runner.os }}-cargo-release-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-release-
 
+      - name: Bump version
+        id: version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -eu
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "バージョンは 1.2.3 の形式で指定してください" >&2
+            exit 1
+          fi
+
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "タグ v${VERSION} は既に存在します" >&2
+            exit 1
+          fi
+
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          jq --arg v "$VERSION" '.version = $v' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+
+          sed -i '' "0,/^version = /s/^version = \".*\"/version = \"${VERSION}\"/" src-tauri/Cargo.toml
+
+          (cd src-tauri && cargo check --quiet)
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
+          git commit -m "chore: bump version to v${{ steps.version.outputs.version }}"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin HEAD:main
+          git push origin "v${{ steps.version.outputs.version }}"
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build Tauri app
         run: npm run tauri build
-
-      - name: Get version
-        id: version
-        run: echo "version=$(jq -r .version src-tauri/tauri.conf.json)" >> "$GITHUB_OUTPUT"
 
       - name: Check if release already exists
         id: check


### PR DESCRIPTION
## Summary
- リリースワークフローのトリガーを `push: branches: [main]` から `workflow_dispatch`（`version` 入力必須）に変更
- 手動実行時に `package.json` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.toml` / `Cargo.lock` のバージョンを一括更新し、コミット・タグ付け・push してからビルド・リリースする

## Background
`tauri.conf.json` のバージョンが `0.1.0` のまま更新されていなかったため、main への push があっても「既存リリースあり」判定でリリース処理がスキップされ続けていた。バージョンbumpを手動運用のミスに依存させず、Actions側からバージョン番号を入力して手動実行する方式に変更した。

## Test plan
- [ ] Actions タブから「Release」ワークフローを Run workflow で実行し、`version` に `0.2.0` 等を入力
- [ ] バージョンが4ファイルに反映されmainにコミット・タグ付けされることを確認
- [ ] ビルド・GitHub Release作成・Homebrew tap更新まで通ることを確認
- [ ] 既存タグを指定した場合にエラーで停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)