### PR TITLE
release: Homebrew tap更新の認証エラーを早期検知できるように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,18 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN が空です。Secretsの設定を確認してください" >&2
+            exit 1
+          fi
+
           VERSION="${{ steps.version.outputs.version }}"
           DMG_NAME="${{ steps.dmg.outputs.name }}"
           DMG_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/${DMG_NAME}"
           SHA256=$(shasum -a 256 "${{ steps.dmg.outputs.path }}" | awk '{print $1}')
 
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ryunosuke121/homebrew-tap.git" tap
+          TAP_URL="https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ryunosuke121/homebrew-tap.git"
+          git clone "$TAP_URL" tap
           cd tap
 
           mkdir -p Casks
@@ -153,4 +159,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/hyut.rb
           git commit -m "Update hyut to v${VERSION}"
-          git push
+          git push "$TAP_URL" HEAD:main

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
 brew install --cask ryunosuke121/tap/hyut
 ```
 
+更新する場合は以下を実行してください。
+
+```bash
+brew update
+brew upgrade --cask hyut
+```
+
 ## 使い方
 
 1. インストール後、hyut を起動します


### PR DESCRIPTION
## Summary
- `HOMEBREW_TAP_TOKEN` が空/無効な場合、`git clone`（publicリポジトリのため匿名でも成功）は通ってしまい `git push` で初めて認証エラーになっていた事象への対処
- トークンが空の場合に早期に分かりやすいエラーで失敗するチェックを追加
- `git push` もcloneと同じURLを明示的に指定し、remote設定のズレによる失敗を防ぐ

## Background
v0.2.0 のリリース実行時、「Update Homebrew Tap」ステップで `git clone` は成功するのに `git push` が `Invalid username or token` で失敗した。原因はワークフローのロジックではなく `HOMEBREW_TAP_TOKEN` Secret自体（値・権限・有効期限）の可能性が高いため、Secret側の確認と合わせてワークフロー側の防御を追加。

## Test plan
- [ ] `HOMEBREW_TAP_TOKEN` Secretの値・権限（`homebrew-tap` への Contents: Read and write）・有効期限を確認する
- [ ] Release ワークフローを再実行し、Homebrew tap への push が成功することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)