### PR TITLE
ci: リリースワークフローの実行名に入力バージョンを表示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release v${{ inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 概要

Release ワークフローに `run-name` を追加し、`workflow_dispatch` で入力した
バージョン番号が Actions の実行名に表示されるようにしました。

```yaml
name: Release
run-name: Release v${{ inputs.version }}
```

## 変更前後

| | 実行名 |
|---|---|
| 変更前 | `Release` |
| 変更後 | `Release v1.2.3` |

Actions の実行一覧で、どのバージョンのリリースなのかが一目で分かるようになります。

## 補足

`run-name` は job の出力を参照できないため、`inputs` コンテキストを使用しています。
本ワークフローのトリガーは `workflow_dispatch` のみで `version` は `required: true` のため、
常に値が入ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)